### PR TITLE
Fix compilation error when ex_esdb is used as a dependency

### DIFF
--- a/system/src/feature_filters.erl
+++ b/system/src/feature_filters.erl
@@ -2,7 +2,7 @@
 
 -export([when_created/1, when_deleted/1, when_updated/1]).
 
--include_lib("../deps/khepri/include/khepri.hrl").
+-include_lib("khepri/include/khepri.hrl").
 
 -spec when_created(Feature :: atom()) -> khepri_evf:event_filter().
 when_created(Feature) ->

--- a/system/src/streams_filters.erl
+++ b/system/src/streams_filters.erl
@@ -2,7 +2,7 @@
 
 -export([by_stream/1, by_event_type/1, by_event_pattern/1, by_event_payload/1]).
 
--include_lib("../deps/khepri/include/khepri.hrl").
+-include_lib("khepri/include/khepri.hrl").
 
 -spec by_stream(Stream :: binary()) -> khepri_evf:tree().
 by_stream(<<"$all">>) ->

--- a/system/src/subscriptions_triggers.erl
+++ b/system/src/subscriptions_triggers.erl
@@ -2,7 +2,7 @@
 
 -export([register_on_created/1, register_on_deleted/1, register_on_updated/1]).
 
--include_lib("../deps/khepri/include/khepri.hrl").
+-include_lib("khepri/include/khepri.hrl").
 
 -spec register_on_created(Store :: khepri:store()) -> ok | {error, term()}.
 register_on_created(Store) ->


### PR DESCRIPTION
### Problem
ex_esdb fails to compile when used as a Hex dependency because it uses relative include paths that only work when the project is at the root level: `-include_lib("../deps/khepri/include/khepri.hrl").` This causes the error: `can't find include lib "../deps/khepri/include/khepri.hrl"`

### Solution

Replace relative paths with standard Erlang `include_lib` directives: `-include_lib("khepri/include/khepri.hrl")`.

Files Changed
- system/src/streams_filters.erl
- system/src/subscriptions_triggers.erl
- system/src/feature_filters.erl

### Configuration Instructions

When using ex_esdb as a dependency, configure it in your `config/config.exs` or `config/runtime.exs`:

### For single-node deployment (e.g., Fly.io)
```elixir
config :ex_esdb,
  khepri: [
    db_type: :single,
    store_id: :your_event_store,
    data_dir: "/path/to/event/store/data",
    pub_sub: MyApp.PubSub
  ]
```

### Configuration Options:

- `db_type`: :single (default) or :cluster for distributed mode
- `store_id`: Atom identifier for your event store (default: :ex_esdb_store)
- `data_dir`: Where to persist data (default: "/data")
- `pub_sub`: Phoenix.PubSub module or :native for built-in

### For Commanded Integration:

#### mix.exs
```elixir
{:ex_esdb, "~> 0.1.0"},
{:ex_esdb_commanded, "~> 0.1.0"},
{:commanded, "~> 1.4"}
```

#### config/config.exs
```elixir
config :my_app, MyApp.Commanded,
  event_store: [
    adapter: ExESDB.Commanded.Adapter,
    event_store: MyApp.EventStore
  ]
```

### Testing

Tested successfully in an Elixir 1.18.3 / OTP 27 project with:
- Commanded 1.4.8
- ex_esdb_commanded 0.1.0
- Single-node configuration